### PR TITLE
Decouple default route from route table definitions

### DIFF
--- a/modules/terraform-zsac-network-aws/outputs.tf
+++ b/modules/terraform-zsac-network-aws/outputs.tf
@@ -8,9 +8,19 @@ output "ac_subnet_ids" {
   value       = data.aws_subnet.ac_subnet_selected[*].id
 }
 
+output "ac_route_table_ids" {
+  description = "App Connector Route Table IDs"
+  value       = [for rt in aws_route_table.ac_rt : rt.id]
+}
+
 output "public_subnet_ids" {
   description = "Public Subnet ID"
   value       = aws_subnet.public_subnet[*].id
+}
+
+output "public_route_table_id" {
+  description = "Public Route Table ID"
+  value       = var.byo_ngw == false ? aws_route_table.public_rt[0].id : null
 }
 
 output "nat_gateway_ips" {


### PR DESCRIPTION
This allows additional routes to be associated with the generated route tables, without them being clobbered on successive terraform runs.

See the [notes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) on why `route` blocks inside the `aws_route_table` resource limit the ability to create other routes.