### PR TITLE
feat: update ZPA provider constraints and version profile defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+### [1.5.2] (2025-09-24)
+
+### Changes
+
+* **zpa provider:** Removed version constraints to allow latest provider versions
+* **app connector group:** Changed default `app_connector_group_version_profile_id` from "2" to "0" (Default version profile)
+
 ### [1.5.1](https://github.com/zscaler/terraform-aws-zpa-app-connector-modules/compare/v1.5.0...v1.5.1) (2025-04-07)
 
 

--- a/examples/ac/README.md
+++ b/examples/ac/README.md
@@ -47,7 +47,6 @@ From ac directory execute:
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0.0 |
-| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 4.0.0 |
 
 ## Providers
 
@@ -101,7 +100,7 @@ From ac directory execute:
 | <a name="input_app_connector_group_override_version_profile"></a> [app\_connector\_group\_override\_version\_profile](#input\_app\_connector\_group\_override\_version\_profile) | Optional: Whether the default version profile of the App Connector Group is applied or overridden. Default: false | `bool` | `true` | no |
 | <a name="input_app_connector_group_upgrade_day"></a> [app\_connector\_group\_upgrade\_day](#input\_app\_connector\_group\_upgrade\_day) | Optional: App Connectors in this group will attempt to update to a newer version of the software during this specified day. Default value: SUNDAY. List of valid days (i.e., SUNDAY, MONDAY, etc) | `string` | `"SUNDAY"` | no |
 | <a name="input_app_connector_group_upgrade_time_in_secs"></a> [app\_connector\_group\_upgrade\_time\_in\_secs](#input\_app\_connector\_group\_upgrade\_time\_in\_secs) | Optional: App Connectors in this group will attempt to update to a newer version of the software during this specified time. Default value: 66600. Integer in seconds (i.e., 66600). The integer should be greater than or equal to 0 and less than 86400, in 15 minute intervals | `string` | `"66600"` | no |
-| <a name="input_app_connector_group_version_profile_id"></a> [app\_connector\_group\_version\_profile\_id](#input\_app\_connector\_group\_version\_profile\_id) | Optional: ID of the version profile. To learn more, see Version Profile Use Cases. https://help.zscaler.com/zpa/configuring-version-profile | `string` | `"2"` | no |
+| <a name="input_app_connector_group_version_profile_id"></a> [app\_connector\_group\_version\_profile\_id](#input\_app\_connector\_group\_version\_profile\_id) | Optional: ID of the version profile. To learn more, see Version Profile Use Cases. https://help.zscaler.com/zpa/configuring-version-profile | `string` | `"0"` | no |
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | enable/disable public IP addresses on App Connector instances. Setting this to true will result in the following: Dynamic Public IP address on the App Connector VM Instance will be enabled; no EIP or NAT Gateway resources will be created; and the App Connector Route Table default route next-hop will be set as the IGW | `bool` | `false` | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region. | `string` | `"us-west-2"` | no |
 | <a name="input_az_count"></a> [az\_count](#input\_az\_count) | Default number of subnets to create based on availability zone input | `number` | `2` | no |

--- a/examples/ac/terraform.tfvars
+++ b/examples/ac/terraform.tfvars
@@ -34,7 +34,7 @@ app_connector_group_country_code = "US"
 #app_connector_group_upgrade_day                = "SUNDAY"
 #app_connector_group_upgrade_time_in_secs       = "66600"
 #app_connector_group_override_version_profile   = true
-#app_connector_group_version_profile_id         = "2"
+#app_connector_group_version_profile_id         = "0"
 #app_connector_group_dns_query_type             = "IPV4_IPV6"
 
 

--- a/examples/ac/variables.tf
+++ b/examples/ac/variables.tf
@@ -259,7 +259,7 @@ variable "app_connector_group_override_version_profile" {
 variable "app_connector_group_version_profile_id" {
   type        = string
   description = "Optional: ID of the version profile. To learn more, see Version Profile Use Cases. https://help.zscaler.com/zpa/configuring-version-profile"
-  default     = "2"
+  default     = "0"
 
   validation {
     condition = (

--- a/examples/ac/versions.tf
+++ b/examples/ac/versions.tf
@@ -21,8 +21,7 @@ terraform {
       version = "~> 4.0.0"
     }
     zpa = {
-      source  = "zscaler/zpa"
-      version = "~> 4.0.0"
+      source = "zscaler/zpa"
     }
   }
 

--- a/examples/ac_asg/README.md
+++ b/examples/ac_asg/README.md
@@ -47,7 +47,6 @@ From ac_asg directory execute:
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0.0 |
-| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 4.0.0 |
 
 ## Providers
 
@@ -100,7 +99,7 @@ From ac_asg directory execute:
 | <a name="input_app_connector_group_override_version_profile"></a> [app\_connector\_group\_override\_version\_profile](#input\_app\_connector\_group\_override\_version\_profile) | Optional: Whether the default version profile of the App Connector Group is applied or overridden. Default: false | `bool` | `true` | no |
 | <a name="input_app_connector_group_upgrade_day"></a> [app\_connector\_group\_upgrade\_day](#input\_app\_connector\_group\_upgrade\_day) | Optional: App Connectors in this group will attempt to update to a newer version of the software during this specified day. Default value: SUNDAY. List of valid days (i.e., SUNDAY, MONDAY, etc) | `string` | `"SUNDAY"` | no |
 | <a name="input_app_connector_group_upgrade_time_in_secs"></a> [app\_connector\_group\_upgrade\_time\_in\_secs](#input\_app\_connector\_group\_upgrade\_time\_in\_secs) | Optional: App Connectors in this group will attempt to update to a newer version of the software during this specified time. Default value: 66600. Integer in seconds (i.e., 66600). The integer should be greater than or equal to 0 and less than 86400, in 15 minute intervals | `string` | `"66600"` | no |
-| <a name="input_app_connector_group_version_profile_id"></a> [app\_connector\_group\_version\_profile\_id](#input\_app\_connector\_group\_version\_profile\_id) | Optional: ID of the version profile. To learn more, see Version Profile Use Cases. https://help.zscaler.com/zpa/configuring-version-profile | `string` | `"2"` | no |
+| <a name="input_app_connector_group_version_profile_id"></a> [app\_connector\_group\_version\_profile\_id](#input\_app\_connector\_group\_version\_profile\_id) | Optional: ID of the version profile. To learn more, see Version Profile Use Cases. https://help.zscaler.com/zpa/configuring-version-profile | `string` | `"0"` | no |
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | enable/disable public IP addresses on App Connector instances. Setting this to true will result in the following: Dynamic Public IP address on the App Connector VM Instance will be enabled; no EIP or NAT Gateway resources will be created; and the App Connector Route Table default route next-hop will be set as the IGW | `bool` | `false` | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region. | `string` | `"us-west-2"` | no |
 | <a name="input_az_count"></a> [az\_count](#input\_az\_count) | Default number of subnets to create based on availability zone input | `number` | `2` | no |

--- a/examples/ac_asg/terraform.tfvars
+++ b/examples/ac_asg/terraform.tfvars
@@ -34,7 +34,7 @@
 #app_connector_group_upgrade_day                = "SUNDAY"
 #app_connector_group_upgrade_time_in_secs       = "66600"
 #app_connector_group_override_version_profile   = true
-#app_connector_group_version_profile_id         = "2"
+#app_connector_group_version_profile_id         = "0"
 #app_connector_group_dns_query_type             = "IPV4_IPV6"
 
 

--- a/examples/ac_asg/variables.tf
+++ b/examples/ac_asg/variables.tf
@@ -334,7 +334,7 @@ variable "app_connector_group_override_version_profile" {
 variable "app_connector_group_version_profile_id" {
   type        = string
   description = "Optional: ID of the version profile. To learn more, see Version Profile Use Cases. https://help.zscaler.com/zpa/configuring-version-profile"
-  default     = "2"
+  default     = "0"
 
   validation {
     condition = (

--- a/examples/ac_asg/versions.tf
+++ b/examples/ac_asg/versions.tf
@@ -21,8 +21,7 @@ terraform {
       version = "~> 4.0.0"
     }
     zpa = {
-      source  = "zscaler/zpa"
-      version = "~> 4.0.0"
+      source = "zscaler/zpa"
     }
   }
 

--- a/examples/base_ac/README.md
+++ b/examples/base_ac/README.md
@@ -48,7 +48,6 @@ From base_ac directory execute:
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0.0 |
-| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 4.0.0 |
 
 ## Providers
 
@@ -103,7 +102,7 @@ From base_ac directory execute:
 | <a name="input_app_connector_group_override_version_profile"></a> [app\_connector\_group\_override\_version\_profile](#input\_app\_connector\_group\_override\_version\_profile) | Optional: Whether the default version profile of the App Connector Group is applied or overridden. Default: false | `bool` | `true` | no |
 | <a name="input_app_connector_group_upgrade_day"></a> [app\_connector\_group\_upgrade\_day](#input\_app\_connector\_group\_upgrade\_day) | Optional: App Connectors in this group will attempt to update to a newer version of the software during this specified day. Default value: SUNDAY. List of valid days (i.e., SUNDAY, MONDAY, etc) | `string` | `"SUNDAY"` | no |
 | <a name="input_app_connector_group_upgrade_time_in_secs"></a> [app\_connector\_group\_upgrade\_time\_in\_secs](#input\_app\_connector\_group\_upgrade\_time\_in\_secs) | Optional: App Connectors in this group will attempt to update to a newer version of the software during this specified time. Default value: 66600. Integer in seconds (i.e., 66600). The integer should be greater than or equal to 0 and less than 86400, in 15 minute intervals | `string` | `"66600"` | no |
-| <a name="input_app_connector_group_version_profile_id"></a> [app\_connector\_group\_version\_profile\_id](#input\_app\_connector\_group\_version\_profile\_id) | Optional: ID of the version profile. To learn more, see Version Profile Use Cases. https://help.zscaler.com/zpa/configuring-version-profile | `string` | `"2"` | no |
+| <a name="input_app_connector_group_version_profile_id"></a> [app\_connector\_group\_version\_profile\_id](#input\_app\_connector\_group\_version\_profile\_id) | Optional: ID of the version profile. To learn more, see Version Profile Use Cases. https://help.zscaler.com/zpa/configuring-version-profile | `string` | `"0"` | no |
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | enable/disable public IP addresses on App Connector instances. Setting this to true will result in the following: Dynamic Public IP address on the App Connector VM Instance will be enabled; no EIP or NAT Gateway resources will be created; and the App Connector Route Table default route next-hop will be set as the IGW | `bool` | `false` | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region. | `string` | `"us-west-2"` | no |
 | <a name="input_az_count"></a> [az\_count](#input\_az\_count) | Default number of subnets to create based on availability zone input | `number` | `2` | no |

--- a/examples/base_ac/terraform.tfvars
+++ b/examples/base_ac/terraform.tfvars
@@ -34,7 +34,7 @@
 #app_connector_group_upgrade_day                = "SUNDAY"
 #app_connector_group_upgrade_time_in_secs       = "66600"
 # app_connector_group_override_version_profile   = true
-# app_connector_group_version_profile_id          = "2"
+# app_connector_group_version_profile_id          = "0"
 #app_connector_group_dns_query_type             = "IPV4_IPV6"
 
 

--- a/examples/base_ac/variables.tf
+++ b/examples/base_ac/variables.tf
@@ -209,7 +209,7 @@ variable "app_connector_group_override_version_profile" {
 variable "app_connector_group_version_profile_id" {
   type        = string
   description = "Optional: ID of the version profile. To learn more, see Version Profile Use Cases. https://help.zscaler.com/zpa/configuring-version-profile"
-  default     = "2"
+  default     = "0"
 
   validation {
     condition = (

--- a/examples/base_ac/versions.tf
+++ b/examples/base_ac/versions.tf
@@ -21,8 +21,7 @@ terraform {
       version = "~> 4.0.0"
     }
     zpa = {
-      source  = "zscaler/zpa"
-      version = "~> 4.0.0"
+      source = "zscaler/zpa"
     }
   }
 

--- a/examples/base_ac_asg/README.md
+++ b/examples/base_ac_asg/README.md
@@ -47,7 +47,6 @@ From base_ac_asg directory execute:
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0.0 |
-| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 4.0.0 |
 
 ## Providers
 
@@ -101,7 +100,7 @@ From base_ac_asg directory execute:
 | <a name="input_app_connector_group_override_version_profile"></a> [app\_connector\_group\_override\_version\_profile](#input\_app\_connector\_group\_override\_version\_profile) | Optional: Whether the default version profile of the App Connector Group is applied or overridden. Default: false | `bool` | `true` | no |
 | <a name="input_app_connector_group_upgrade_day"></a> [app\_connector\_group\_upgrade\_day](#input\_app\_connector\_group\_upgrade\_day) | Optional: App Connectors in this group will attempt to update to a newer version of the software during this specified day. Default value: SUNDAY. List of valid days (i.e., SUNDAY, MONDAY, etc) | `string` | `"SUNDAY"` | no |
 | <a name="input_app_connector_group_upgrade_time_in_secs"></a> [app\_connector\_group\_upgrade\_time\_in\_secs](#input\_app\_connector\_group\_upgrade\_time\_in\_secs) | Optional: App Connectors in this group will attempt to update to a newer version of the software during this specified time. Default value: 66600. Integer in seconds (i.e., 66600). The integer should be greater than or equal to 0 and less than 86400, in 15 minute intervals | `string` | `"66600"` | no |
-| <a name="input_app_connector_group_version_profile_id"></a> [app\_connector\_group\_version\_profile\_id](#input\_app\_connector\_group\_version\_profile\_id) | Optional: ID of the version profile. To learn more, see Version Profile Use Cases. https://help.zscaler.com/zpa/configuring-version-profile | `string` | `"2"` | no |
+| <a name="input_app_connector_group_version_profile_id"></a> [app\_connector\_group\_version\_profile\_id](#input\_app\_connector\_group\_version\_profile\_id) | Optional: ID of the version profile. To learn more, see Version Profile Use Cases. https://help.zscaler.com/zpa/configuring-version-profile | `string` | `"0"` | no |
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | enable/disable public IP addresses on App Connector instances | `bool` | `false` | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region. | `string` | `"us-west-2"` | no |
 | <a name="input_az_count"></a> [az\_count](#input\_az\_count) | Default number of subnets to create based on availability zone input | `number` | `2` | no |

--- a/examples/base_ac_asg/terraform.tfvars
+++ b/examples/base_ac_asg/terraform.tfvars
@@ -34,7 +34,7 @@
 #app_connector_group_upgrade_day                = "SUNDAY"
 #app_connector_group_upgrade_time_in_secs       = "66600"
 #app_connector_group_override_version_profile   = true
-#app_connector_group_version_profile_id         = "2"
+#app_connector_group_version_profile_id         = "0"
 #app_connector_group_dns_query_type             = "IPV4_IPV6"
 
 

--- a/examples/base_ac_asg/variables.tf
+++ b/examples/base_ac_asg/variables.tf
@@ -266,7 +266,7 @@ variable "app_connector_group_override_version_profile" {
 variable "app_connector_group_version_profile_id" {
   type        = string
   description = "Optional: ID of the version profile. To learn more, see Version Profile Use Cases. https://help.zscaler.com/zpa/configuring-version-profile"
-  default     = "2"
+  default     = "0"
 
   validation {
     condition = (

--- a/examples/base_ac_asg/versions.tf
+++ b/examples/base_ac_asg/versions.tf
@@ -21,8 +21,7 @@ terraform {
       version = "~> 4.0.0"
     }
     zpa = {
-      source  = "zscaler/zpa"
-      version = "~> 4.0.0"
+      source = "zscaler/zpa"
     }
   }
 

--- a/modules/terraform-zpa-app-connector-group/README.md
+++ b/modules/terraform-zpa-app-connector-group/README.md
@@ -8,13 +8,12 @@ This module provides the resources necessary to create a new ZPA App Connector G
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 4.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_zpa"></a> [zpa](#provider\_zpa) | ~> 4.0.0 |
+| <a name="provider_zpa"></a> [zpa](#provider\_zpa) | n/a |
 
 ## Modules
 
@@ -41,7 +40,7 @@ No modules.
 | <a name="input_app_connector_group_override_version_profile"></a> [app\_connector\_group\_override\_version\_profile](#input\_app\_connector\_group\_override\_version\_profile) | Optional: Whether the default version profile of the App Connector Group is applied or overridden. Default: false | `bool` | `true` | no |
 | <a name="input_app_connector_group_upgrade_day"></a> [app\_connector\_group\_upgrade\_day](#input\_app\_connector\_group\_upgrade\_day) | Optional: App Connectors in this group will attempt to update to a newer version of the software during this specified day. Default value: SUNDAY. List of valid days (i.e., SUNDAY, MONDAY, etc) | `string` | `"SUNDAY"` | no |
 | <a name="input_app_connector_group_upgrade_time_in_secs"></a> [app\_connector\_group\_upgrade\_time\_in\_secs](#input\_app\_connector\_group\_upgrade\_time\_in\_secs) | Optional: App Connectors in this group will attempt to update to a newer version of the software during this specified time. Default value: 66600. Integer in seconds (i.e., 66600). The integer should be greater than or equal to 0 and less than 86400, in 15 minute intervals | `string` | `"66600"` | no |
-| <a name="input_app_connector_group_version_profile_id"></a> [app\_connector\_group\_version\_profile\_id](#input\_app\_connector\_group\_version\_profile\_id) | Optional: ID of the version profile. To learn more, see Version Profile Use Cases. https://help.zscaler.com/zpa/configuring-version-profile | `string` | `"2"` | no |
+| <a name="input_app_connector_group_version_profile_id"></a> [app\_connector\_group\_version\_profile\_id](#input\_app\_connector\_group\_version\_profile\_id) | Optional: ID of the version profile. To learn more, see Version Profile Use Cases. https://help.zscaler.com/zpa/configuring-version-profile | `string` | `"0"` | no |
 
 ## Outputs
 

--- a/modules/terraform-zpa-app-connector-group/variables.tf
+++ b/modules/terraform-zpa-app-connector-group/variables.tf
@@ -57,7 +57,7 @@ variable "app_connector_group_override_version_profile" {
 variable "app_connector_group_version_profile_id" {
   type        = string
   description = "Optional: ID of the version profile. To learn more, see Version Profile Use Cases. https://help.zscaler.com/zpa/configuring-version-profile"
-  default     = "2"
+  default     = "0"
 
   validation {
     condition = (

--- a/modules/terraform-zpa-app-connector-group/versions.tf
+++ b/modules/terraform-zpa-app-connector-group/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     zpa = {
-      source  = "zscaler/zpa"
-      version = "~> 4.0.0"
+      source = "zscaler/zpa"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zpa-provisioning-key/README.md
+++ b/modules/terraform-zpa-provisioning-key/README.md
@@ -10,13 +10,12 @@ There is a "BYO" option where you can conditionally create new or reference an e
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 4.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_zpa"></a> [zpa](#provider\_zpa) | ~> 4.0.0 |
+| <a name="provider_zpa"></a> [zpa](#provider\_zpa) | n/a |
 
 ## Modules
 

--- a/modules/terraform-zpa-provisioning-key/versions.tf
+++ b/modules/terraform-zpa-provisioning-key/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     zpa = {
-      source  = "zscaler/zpa"
-      version = "~> 4.0.0"
+      source = "zscaler/zpa"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"


### PR DESCRIPTION
## Changes

- **Remove ZPA provider version constraints** to allow latest provider versions across all modules and examples
- **Change default app_connector_group_version_profile_id** from "2" (New Release) to "0" (Default version profile)
- **Update documentation and examples** to reflect new defaults

## Background

This addresses user complaints about provider version restrictions that prevented them from using the latest ZPA provider versions. The change allows users to automatically receive the latest provider features and bug fixes.

The version profile ID default change aligns with ZPA's default behavior, ensuring App Connector Groups use the default version profile rather than forcing the newest release profile.

## Files Changed

- All `versions.tf` files: Removed ZPA provider version constraints
- All `variables.tf` files: Updated default version_profile_id from "2" to "0"
- All `terraform.tfvars` files: Updated example values
- All `README.md` files: Updated documentation to reflect new defaults
- `CHANGELOG.md`: Added version 1.5.2 entries

## Impact

- ✅ Users can now use the latest ZPA provider versions automatically
- ✅ App Connector Groups default to ZPA's default version profile behavior
- ✅ No breaking changes - existing configurations continue to work
- ⚠️ TFLint warnings about missing version constraints are expected and intentional

## Testing

- [x] All Terraform validation passes
- [x] Documentation automatically updated via terraform-docs
- [x] No linting errors introduced (TFLint warnings are intentional)

Resolves user feedback about ZPA provider version restrictions.