### PR TITLE
make resource_tag variables optional and require name_prefix

### DIFF
--- a/modules/terraform-zsac-acvm-aws/variables.tf
+++ b/modules/terraform-zsac-acvm-aws/variables.tf
@@ -1,13 +1,12 @@
 variable "name_prefix" {
   type        = string
   description = "A prefix to associate to all the App Connector module resources"
-  default     = null
 }
 
 variable "resource_tag" {
   type        = string
   description = "A tag to associate to all the App Connector module resources"
-  default     = null
+  default     = ""
 }
 
 variable "global_tags" {

--- a/modules/terraform-zsac-asg-aws/variables.tf
+++ b/modules/terraform-zsac-asg-aws/variables.tf
@@ -1,13 +1,12 @@
 variable "name_prefix" {
   type        = string
   description = "A prefix to associate to all the App Connector module resources"
-  default     = null
 }
 
 variable "resource_tag" {
   type        = string
   description = "A tag to associate to all the App Connector module resources"
-  default     = null
+  default     = ""
 }
 
 variable "global_tags" {

--- a/modules/terraform-zsac-bastion-aws/variables.tf
+++ b/modules/terraform-zsac-bastion-aws/variables.tf
@@ -1,13 +1,12 @@
 variable "name_prefix" {
   type        = string
   description = "A prefix to associate to all the Workload module resources"
-  default     = null
 }
 
 variable "resource_tag" {
   type        = string
   description = "A tag to associate to all the Workload module resources"
-  default     = null
+  default     = ""
 }
 
 variable "global_tags" {

--- a/modules/terraform-zsac-iam-aws/variables.tf
+++ b/modules/terraform-zsac-iam-aws/variables.tf
@@ -1,13 +1,12 @@
 variable "name_prefix" {
   type        = string
   description = "A prefix to associate to all the App Connector IAM module resources"
-  default     = null
 }
 
 variable "resource_tag" {
   type        = string
   description = "A tag to associate to all the App Connector IAM module resources"
-  default     = null
+  default     = ""
 }
 
 variable "global_tags" {

--- a/modules/terraform-zsac-network-aws/variables.tf
+++ b/modules/terraform-zsac-network-aws/variables.tf
@@ -1,13 +1,12 @@
 variable "name_prefix" {
   type        = string
   description = "A prefix to associate to all the network module resources"
-  default     = null
 }
 
 variable "resource_tag" {
   type        = string
   description = "A tag to associate to all the network module resources"
-  default     = null
+  default     = ""
 }
 
 variable "global_tags" {

--- a/modules/terraform-zsac-sg-aws/variables.tf
+++ b/modules/terraform-zsac-sg-aws/variables.tf
@@ -1,13 +1,12 @@
 variable "name_prefix" {
   type        = string
   description = "A prefix to associate to all the App Connector Security Group module resources"
-  default     = null
 }
 
 variable "resource_tag" {
   type        = string
   description = "A tag to associate to all the App Connector Security Group module resources"
-  default     = null
+  default     = ""
 }
 
 variable "global_tags" {


### PR DESCRIPTION
Using null as default value results in "Invalid template interpolation value", therefore

- name_prefix is now required by removing default_value
- resource_tag is an optional value for me, so an empty string will still fullfil its function

