### PR TITLE
fix: make example applies idempotent and avoid VPC quota exhaustion

### DIFF
--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -21,6 +21,10 @@ jobs:
     with:
       cloud: aws
       validate_max_parallel: 20
-      test_max_parallel: 5
+      # Each example provisions its own VPC during the Idempotence apply. The
+      # account's default VPCs-per-Region quota (5) plus the existing default
+      # VPC means running too many examples in parallel hits VpcLimitExceeded.
+      # Cap concurrent apply jobs at 2 to stay safely under the quota.
+      test_max_parallel: 2
       fail_fast: false
       terratest_action: Idempotence # keep in mind that this has to start with capital letter

--- a/examples/ac/versions.tf
+++ b/examples/ac/versions.tf
@@ -36,6 +36,24 @@ terraform {
 # Configure the AWS Provider
 provider "aws" {
   region = var.aws_region
+
+  # Some AWS accounts enforce Organization tag policies that automatically
+  # attach governance tags (cost center, owner, environment, etc.) to created
+  # resources. Terraform does not manage these tags, so without ignore_tags it
+  # detects them as drift on subsequent plans and the apply is non-idempotent.
+  # Ignoring these account-managed tag keys keeps plans clean.
+  ignore_tags {
+    keys = [
+      "acctowner",
+      "area",
+      "costcenter",
+      "domain",
+      "envtype",
+      "jiraname",
+      "opsteam",
+      "subarea",
+    ]
+  }
 }
 
 provider "zpa" {

--- a/examples/ac_asg/versions.tf
+++ b/examples/ac_asg/versions.tf
@@ -40,6 +40,24 @@ terraform {
 # Configure the AWS Provider
 provider "aws" {
   region = var.aws_region
+
+  # Some AWS accounts enforce Organization tag policies that automatically
+  # attach governance tags (cost center, owner, environment, etc.) to created
+  # resources. Terraform does not manage these tags, so without ignore_tags it
+  # detects them as drift on subsequent plans and the apply is non-idempotent.
+  # Ignoring these account-managed tag keys keeps plans clean.
+  ignore_tags {
+    keys = [
+      "acctowner",
+      "area",
+      "costcenter",
+      "domain",
+      "envtype",
+      "jiraname",
+      "opsteam",
+      "subarea",
+    ]
+  }
 }
 
 provider "zpa" {

--- a/examples/base/versions.tf
+++ b/examples/base/versions.tf
@@ -28,4 +28,22 @@ terraform {
 # Configure the AWS Provider
 provider "aws" {
   region = var.aws_region
+
+  # Some AWS accounts enforce Organization tag policies that automatically
+  # attach governance tags (cost center, owner, environment, etc.) to created
+  # resources. Terraform does not manage these tags, so without ignore_tags it
+  # detects them as drift on subsequent plans and the apply is non-idempotent.
+  # Ignoring these account-managed tag keys keeps plans clean.
+  ignore_tags {
+    keys = [
+      "acctowner",
+      "area",
+      "costcenter",
+      "domain",
+      "envtype",
+      "jiraname",
+      "opsteam",
+      "subarea",
+    ]
+  }
 }

--- a/examples/base_ac/versions.tf
+++ b/examples/base_ac/versions.tf
@@ -36,6 +36,24 @@ terraform {
 # Configure the AWS Provider
 provider "aws" {
   region = var.aws_region
+
+  # Some AWS accounts enforce Organization tag policies that automatically
+  # attach governance tags (cost center, owner, environment, etc.) to created
+  # resources. Terraform does not manage these tags, so without ignore_tags it
+  # detects them as drift on subsequent plans and the apply is non-idempotent.
+  # Ignoring these account-managed tag keys keeps plans clean.
+  ignore_tags {
+    keys = [
+      "acctowner",
+      "area",
+      "costcenter",
+      "domain",
+      "envtype",
+      "jiraname",
+      "opsteam",
+      "subarea",
+    ]
+  }
 }
 
 provider "zpa" {

--- a/examples/base_ac_asg/versions.tf
+++ b/examples/base_ac_asg/versions.tf
@@ -40,6 +40,24 @@ terraform {
 # Configure the AWS Provider
 provider "aws" {
   region = var.aws_region
+
+  # Some AWS accounts enforce Organization tag policies that automatically
+  # attach governance tags (cost center, owner, environment, etc.) to created
+  # resources. Terraform does not manage these tags, so without ignore_tags it
+  # detects them as drift on subsequent plans and the apply is non-idempotent.
+  # Ignoring these account-managed tag keys keeps plans clean.
+  ignore_tags {
+    keys = [
+      "acctowner",
+      "area",
+      "costcenter",
+      "domain",
+      "envtype",
+      "jiraname",
+      "opsteam",
+      "subarea",
+    ]
+  }
 }
 
 provider "zpa" {


### PR DESCRIPTION
## Summary

Fixes two failures surfaced by the Release CI (Idempotence) run:

- **`examples/base` non-idempotent apply** — the AWS account enforces an Organization tag policy that auto-attaches governance tags (`acctowner`, `area`, `costcenter`, `domain`, `envtype`, `jiraname`, `opsteam`, `subarea`) to created resources. Terraform doesn't manage these, so the second apply planned to strip them (`1 to change`), failing the idempotence check. Added an `ignore_tags` block to the `aws` provider in all five examples so account-managed tags no longer register as drift.
- **`examples/base_ac_asg` `VpcLimitExceeded`** — each example provisions its own VPC during the Idempotence apply. Running 5 examples in parallel against the default VPCs-per-Region quota (5, plus the existing default VPC) intermittently exceeds the limit. Capped `test_max_parallel` to `2` in `release_ci.yml` to stay safely under quota. No leaked VPCs were found; the failure was transient concurrency.

## Changes

- `examples/{ac,ac_asg,base,base_ac,base_ac_asg}/versions.tf`: add `ignore_tags` to the AWS provider.
- `.github/workflows/release_ci.yml`: `test_max_parallel: 5` -> `2`.

## Test plan

- [x] `terraform fmt` clean across all examples
- [x] `terraform validate` passes for all five examples
- [x] pre-commit hooks (fmt/docs/tflint/detect-secrets) pass
- [x] Release CI Idempotence run is green