### PR TITLE
fix: ignore ZPA-derived city_country drift on app connector group

### DIFF
--- a/modules/terraform-zpa-app-connector-group/main.tf
+++ b/modules/terraform-zpa-app-connector-group/main.tf
@@ -23,4 +23,14 @@ resource "zpa_app_connector_group" "app_connector_group" {
   # "Connector" certificate by name), so enrollment_cert_id is intentionally not
   # set here. Leave user_codes empty when onboarding via provisioning key.
   user_codes = var.user_codes
+
+  lifecycle {
+    # The ZPA API derives city_country from the supplied latitude/longitude and
+    # returns it on read, but the provider schema marks the field Optional
+    # (not Computed). When city_country is left empty in config, Terraform reads
+    # the API-derived value into state and then perpetually plans to reset it to
+    # "", making the apply non-idempotent. Ignoring post-create changes to this
+    # API-managed field keeps plans clean.
+    ignore_changes = [city_country]
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #44. The Release CI Idempotence run failed on `examples/ac` because the ZPA App Connector Group plan was non-idempotent:

```
~ resource "zpa_app_connector_group" "app_connector_group" {
    - city_country = "San Jose, US" -> null
```

**Root cause:** the ZPA API derives `city_country` from the supplied latitude/longitude and returns it on read, but in the provider schema the field is `Optional` with `Computed` commented out (`resource_zpa_app_connector_group.go`). With an empty `city_country` in config, Terraform reads the API-derived value into state and then perpetually plans to reset it to `""`, making the second apply non-idempotent.

**Fix:** add `lifecycle { ignore_changes = [city_country] }` to the `zpa_app_connector_group` resource in the connector group module. Because the module is shared, this covers `ac`, `ac_asg`, `base_ac`, and `base_ac_asg`.

## Changes

- `modules/terraform-zpa-app-connector-group/main.tf`: ignore post-create changes to `city_country`.

## Test plan

- [x] `terraform fmt` / `validate` pass for the module and `examples/ac`
- [x] pre-commit hooks (fmt/docs/tflint/detect-secrets) pass
- [x] Release CI Idempotence run is green